### PR TITLE
Fix bug

### DIFF
--- a/Trees/bst.py
+++ b/Trees/bst.py
@@ -131,7 +131,6 @@ class Tree:
 					delNodeParent = delNode
 					delNode = delNode.leftChild
 					
-				self.root.value = delNode.value
 				if delNode.rightChild:
 					if delNodeParent.value > delNode.value:
 						delNodeParent.leftChild = delNode.rightChild
@@ -142,6 +141,7 @@ class Tree:
 						delNodeParent.leftChild = None
 					else:
 						delNodeParent.rightChild = None
+				self.root.value = delNode.value
 						
 			return True
 		


### PR DESCRIPTION
The current code would fail when remove the root element in a tree where right subtree only have right child.
        #                     17
        #                 0       20
        #              -5   5        25

Current code would produce a result with duplicate elements

        #                     20
        #                 0       20
        #              -5   5        25

Trick is to move one the assignment to root value to the bottom