### PR TITLE
Updated remove function for a corner case

### DIFF
--- a/LinkedLists/DoublyLinkedList1.py
+++ b/LinkedLists/DoublyLinkedList1.py
@@ -53,7 +53,7 @@ class LinkedList (object):
                 if prev:
                     prev.set_next(next)
                 else:
-                    self.root = this_node
+                    self.root = next
                 self.size -= 1
                 return True		# data removed
             else:


### PR DESCRIPTION
While removing the first node from the Linked list the root should be updated with the next node rather than the same node.
For example: creating a linked list of 1 -> 4 -> 5 and then removing the element 1 will not remove it with the current logic.
myList = LinkedList()
myList.add(5)
myList.add(4)
myList.add(1)
print("Remove 1")
myList.remove(1)
1 does not gets removed.

I have updated the logic so now it works.