### PR TITLE
Fix peek method in MaxHeap to prevent IndexError

### DIFF
--- a/MaxHeap.py
+++ b/MaxHeap.py
@@ -15,10 +15,10 @@ class MaxHeap:
 		self.__floatUp(len(self.heap) - 1)
 
 	def peek(self):
-		if self.heap[1]:
+		if len(self.heap)>1:
 			return self.heap[1]
-		else:
-			return False
+		else: 
+			return false
 			
 	def pop(self):
 		if len(self.heap) > 2:


### PR DESCRIPTION
Updated the `peek` method to check if the heap contains at least one element before accessing `self.heap[1]`. 
This prevents a potential IndexError when the heap is empty.
